### PR TITLE
if no --output_file_name supplied, no longer use a random name, use a…

### DIFF
--- a/wav_split.py
+++ b/wav_split.py
@@ -55,12 +55,12 @@ if __name__ == '__main__':
     parser.add_argument("--output_file_name",
                         "-o",
                         help="File name of the newly created mono wave file",
-                        type=str,
-                        default=str(uuid.uuid4().int) + ".wav")
+                        type=str)
     parser.add_argument("--channel",
                        help="which channel to keep",
                        type=int, 
                        default=1)
     args = parser.parse_args()
     create_output_dir(args.output_directory)
-    main(args.wav_file, args.output_directory, args.output_file_name, args.channel)
+    output_file_name = args.output_file_name or f'{os.path.basename(args.wav_file).split(".wav")[0]}_channel_{args.channel}.wav'
+    main(args.wav_file, args.output_directory, output_file_name, args.channel)


### PR DESCRIPTION
… name derived from the input file name

The random names were becoming annoying when testing.  If I user wants to generate a file with a random name, that can be done by specifying a random name to the `--output_file_name` command line switch.

I think the random names _can_ be useful in some circumstance...