### PR TITLE
Remove stdout chatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ optional arguments:
                         File name of the newly created mono wave file. If not supplied, the output file is the
                         input file name with the channel appended to the file name.
   --channel CHANNEL     which channel to keep
+  --verbose, -v         prints additional details to stdout
 ```
 
 ## Prerequisites

--- a/wav_split.py
+++ b/wav_split.py
@@ -14,7 +14,7 @@ import argparse
 import os
 from wave_channel import convert_wav_to_mono
 
-def main(wav_file_name, output_directory, output_file_name, channel):
+def main(wav_file_name, output_directory, output_file_name, channel, verbose):
     """Split the Wave."""
     try:
         wf = wave.open(wav_file_name, "rb")
@@ -22,7 +22,7 @@ def main(wav_file_name, output_directory, output_file_name, channel):
         print(f'Error Opening {wav_file_name} : {str(wave_except)}', file=sys.stderr)
     # check for non-mono wavs and convert them, else output message
     if can_be_split(wf):
-        convert_wav_to_mono(wf, output_directory, output_file_name, channel)
+        convert_wav_to_mono(wf, output_directory, output_file_name, channel, verbose)
         print ("Converted to " + output_file_name)
     else:
         print (wav_file_name + " wav is already mono")
@@ -60,7 +60,12 @@ if __name__ == '__main__':
                        help="which channel to keep",
                        type=int, 
                        default=0)
+    parser.add_argument('--verbose', 
+                        '-v', 
+                        action='count', 
+                        default=0,
+                        help="prints additional details to stdout")
     args = parser.parse_args()
     create_output_dir(args.output_directory)
     output_file_name = args.output_file_name or f'{os.path.basename(args.wav_file).split(".wav")[0]}_channel_{args.channel}.wav'
-    main(args.wav_file, args.output_directory, output_file_name, args.channel)
+    main(args.wav_file, args.output_directory, output_file_name, args.channel, args.verbose)

--- a/wave_channel.py
+++ b/wave_channel.py
@@ -8,6 +8,7 @@ Classes:
     InvalidWaveChannel: Exception thrown when an attempt is made to access a channel the doesn't exist in the wave.Wave_read object
 """
 
+from typing import Generator
 import wave
 from time import perf_counter
 import os
@@ -57,7 +58,7 @@ def convert_wav_to_mono(wave_file:wave.Wave_read, output_directory: str, mono_wa
 
 def get_one_channel(wave_file: wave.Wave_read, channel_num=1) -> bytearray:
     """
-    Split out one channel of audio data from the passed Wave_read object
+    Split out one channel of audio data from the passed Wave_read object.
 
     Args:
         wave_file: a wave.Wave_read object that will have one audio channel read into a new file.  This object will not be manipulated
@@ -74,7 +75,7 @@ def get_one_channel(wave_file: wave.Wave_read, channel_num=1) -> bytearray:
 
 def read_wave_channel(wave_file:wave.Wave_read, read_channel_index:int):
     """
-    Generator that Yields the next byte from channel "read_channel_index" of the passed Wave_read object
+    Yield the next() byte from channel "read_channel_index" of the passed Wave_read object.
 
     Args:
         wave_file: a wave.Wave_read object that will have one audio channel read into a new file.  This object will not be manipulated

--- a/wave_channel.py
+++ b/wave_channel.py
@@ -12,7 +12,7 @@ import wave
 from time import perf_counter
 import os
 
-def convert_wav_to_mono(wave_file:wave.Wave_read, output_directory: str, mono_wave_file_name: str, channel_num: int):
+def convert_wav_to_mono(wave_file:wave.Wave_read, output_directory: str, mono_wave_file_name: str, channel_num: int, verbose: int):
     """
     Create a new wave file on disk from one of the channels of the passed Wave_read object.
 
@@ -21,14 +21,15 @@ def convert_wav_to_mono(wave_file:wave.Wave_read, output_directory: str, mono_wa
         output_directory: The directory on disk where the newly created mono wave file will be stored.
         mono_wave_file_name: name to use for the newly created mono wave file
         channel_num: the channel id of the channel that will be read into the new wave file
+        verbose: if set, output additional information about the files and split time
 
     Returns:
         The name of the newly created wave file # TODO this doesn't really make sense
     """
     # only going to keep one of the channels
-
-    print(f'There are {wave_file.getsampwidth()} bytes per sample in this wave')
-    print(f'The sampling frequency is {wave_file.getframerate()}')
+    if verbose:
+        print(f'There are {wave_file.getsampwidth()} bytes per sample in this wave')
+        print(f'The sampling frequency is {wave_file.getframerate()}')
 
     # TODO: Make it configurable which channel to keep
 
@@ -50,7 +51,7 @@ def convert_wav_to_mono(wave_file:wave.Wave_read, output_directory: str, mono_wa
         os.remove(f'{output_directory}/{mono_wave_file_name}')
         raise
 
-    print("Conversion completed in: ", perf_counter() - start_time, "seconds")
+    if verbose: print("Conversion completed in: ", perf_counter() - start_time, "seconds")
 
     return mono_wave_file_name
 


### PR DESCRIPTION
Unnecessary information is output to stdout when the utility is run like the bitrate of the original wave and the time it takes for a channel to be stripped out.  That detail is now only printed when a users specifies `-v` or `--verbose` from the command line